### PR TITLE
Fix markup of security page

### DIFF
--- a/source/security.md
+++ b/source/security.md
@@ -6,9 +6,9 @@ description: See a list of known vulnerabilities which have been fixed and find 
 
 # {{ page.title }}
 
-<a name="security-vulnerabilities" id="security-vulnerabilities"><h2 class="anchor">Security Vulnerabilities</h2></a>
+## Security Vulnerabilities
 
-<a name="CVE-2013-6480"><h3 class="anchor">[CVE-2013-6480] Libcloud doesn't send scrub_data query parameter when destroying a DigitalOcean node</h3></a>
+### [CVE-2013-6480] Libcloud doesn't send scrub\_data query parameter when destroying a DigitalOcean node
 
 **Severity**: Low  
 **Affected Versions**: Apache Libcloud **0.12.3** to **0.13.3** (version prior
@@ -34,7 +34,7 @@ References:
 This vulnerability has been fixed in version 0.13.3. Users who use DigitalOcean
 driver are strongly encouraged to upgrade to this release.
 
-<a name="CVE-2012-3446"><h3 class="anchor">[CVE-2012-3446] Possible SSL MITM due to invalid regular expression used to validate the target server hostname</h3></a>
+### [CVE-2012-3446] Possible SSL MITM due to invalid regular expression used to validate the target server hostname
 
 **Severity**: Medium  
 **Affected Versions**: Apache Libcloud 0.4.2 to 0.11.1 (version prior to 0.4.2
@@ -59,7 +59,7 @@ upgrade to version 0.11.1 or higher.
 This issue was discovered by researchers from the University of Texas at Austin
 (Martin Georgiev, Suman Jana and Vitaly Shmatikov).
 
-<a name="CVE-2010-4340"><h3 class="anchor">[CVE-2010-4340] SSL MITM vulnerability</h3></a>
+### [CVE-2010-4340] SSL MITM vulnerability
 
 **Severity**: Medium  
 **Affected versions**: All the versions prior to **0.4.2**  
@@ -75,11 +75,9 @@ This vulnerability has been fixed in the version 0.4.2. You are strongly
 encouraged to upgrade to this version and set
 `libcloud.security.VERIFY_SSL_CERT` variable to `True`.
 
-<a name="reporting-a-vulnerability" id="reporting-a-vulnerability"><h2 class="anchor">Reporting a Vulnerability</h2></a>
+## Reporting a Vulnerability
 
-<div class="alert alert-info">Please do <strong>not</strong> report security
-issues using our public Github instance. Use the private mailing list
-described bellow.</div>
+_Please do <strong>not</strong> report security issues using our public Github instance. Use the private mailing list described bellow._
 
 If you believe you found a security issue or a vulnerability, please send a
 description of it to our private mailing list at
@@ -92,13 +90,13 @@ Once you've submitted an issue, you should receive an acknowledgment from one
 our of team members in 48 hours or less. If further action is necessary, you
 may receive additional follow-up emails.
 
-<a name="how-are-vulnerabilities-handled" id="how-are-vulnerabilities-handled"><h2 class="anchor">How are vulnerabilities handled?</h2></a>
+## How are vulnerabilities handled?
 
 We follow a standard Apache Software Foundation vulnerability handling process
 which is described at
 [http://www.apache.org/security/committers.html#vulnerability-handling][5].
 
-<a name="errors-and-omissions" id="errors-and-omissions"><h2 class="anchor">Errors and Omissions</h2></a>
+## Errors and Omissions
 
 Please report any errors or omissions to
 <a href="mailto:security@libcloud.apache.org">security@libcloud.apache.org</a>.


### PR DESCRIPTION
Some HTML fragments that aren't picked up by Jekyll were still in the page. This makes the CVE anchors no longer work, but it looks like those haven't worked for a while, so that might be acceptable for now.